### PR TITLE
Patch out `strlen` aliasing implementation

### DIFF
--- a/.github/workflows/build-dependencies.yaml
+++ b/.github/workflows/build-dependencies.yaml
@@ -73,6 +73,12 @@ jobs:
           mv musl-${{ env.MUSL_VERSION }} musl
           mkdir -p install
 
+      - name: Apply patches
+        run: |
+          cd musl
+          git apply ../patches/musl/strlen.patch
+          echo "Patches applied"
+
       - name: Configure
         run: |
           cd musl

--- a/patches/musl/strlen.patch
+++ b/patches/musl/strlen.patch
@@ -1,0 +1,18 @@
+diff --git a/src/string/strlen.c b/src/string/strlen.c
+index 309990f0..4edce373 100644
+--- a/src/string/strlen.c
++++ b/src/string/strlen.c
+@@ -10,13 +10,6 @@
+ size_t strlen(const char *s)
+ {
+ 	const char *a = s;
+-#ifdef __GNUC__
+-	typedef size_t __attribute__((__may_alias__)) word;
+-	const word *w;
+-	for (; (uintptr_t)s % ALIGN; s++) if (!*s) return s-a;
+-	for (w = (const void *)s; !HASZERO(*w); w++);
+-	s = (const void *)w;
+-#endif
+ 	for (; *s; s++);
+ 	return s-a;
+ }


### PR DESCRIPTION
This commit removes the ability for `strlen` to look past the buffer if
compiled with GNUC. This is necessary because otherwise `strlen` will
fail contexts even though user code is not at fault.