### PR TITLE
Re-enable `GNUC` define

### DIFF
--- a/.github/workflows/build-dependencies.yaml
+++ b/.github/workflows/build-dependencies.yaml
@@ -53,8 +53,6 @@ jobs:
       LLVM_LINK_NAME: llvm-link-12
       CC: gclang
       CXX: gclang++
-      CFLAGS: "-fgnuc-version=0"
-      CPPFLAGS: "-fgnuc-version=0"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2


### PR DESCRIPTION
Forgot to add this in the previous PR, but since we patched `strlen` to
work as usual, we can use `GNUC` again.